### PR TITLE
chore: move pr template into .github and remove useless issue template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
+<!-- 
+Thank you for contributing to devstats.
 Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)
 
 Specially:
-- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
+- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for details.
 - Make sure you've added test coverage for new features/metrics.
 - Make sure you have updated documentation.
 - If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
+-->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-Please make sure that You follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md).
-
-Please specify if the issue is a bug or a feature request.


### PR DESCRIPTION
 move pr template into .github and remove useless issue template.